### PR TITLE
Allow non-breaking spaces in and after [ ] and [x]

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ function todoify(token, lastId, options, TokenConstructor) {
 function makeCheckbox(token, id, options, TokenConstructor) {
 	var checkbox = new TokenConstructor('checkbox_input', 'input', 0);
 	checkbox.attrs = [["type", "checkbox"], ["id", id]];
-	var checked = (token.content.indexOf('[x] ') === 0 || token.content.indexOf('[X] ') === 0)
+	var checked = /^\[[xX]\][ \u00A0]/.test(token.content); // if token.content starts with '[x] ' or '[X] '
 	if (checked === true) {
 	  checkbox.attrs.push(["checked", "true"]);
 	}
@@ -115,6 +115,8 @@ function isParagraph(token) { return token.type === 'paragraph_open'; }
 function isListItem(token) { return token.type === 'list_item_open'; }
 
 function startsWithTodoMarkdown(token) {
-	// leading whitespace in a list item is already trimmed off by markdown-it
-	return token.content.indexOf('[ ] ') === 0 || token.content.indexOf('[x] ') === 0 || token.content.indexOf('[X] ') === 0;
+	// The leading whitespace in a list item (token.content) is already trimmed off by markdown-it.
+	// The regex below checks for '[ ] ' or '[x] ' or '[X] ' at the start of the string token.content,
+	// where the space is either a normal space or a non-breaking space (character 160 = \u00A0).
+	return /^\[[xX \u00A0]\][ \u00A0]/.test(token.content);
 }

--- a/test/fixtures/dirty.md
+++ b/test/fixtures/dirty.md
@@ -5,3 +5,24 @@
 - [x ] not a todo item 4
 - [ x ] not a todo item 5
 -   [x] todo item 6
+- [ X] not a todo item 7
+- [X ] not a todo item 8
+- [ X ] not a todo item 9
+-   [X] todo item 10
+-   [ ] unchecked todo item with non-breaking space 11
+- [ ]
+- [  ] not a todo item with 2 non-breaking spaces 12
+- [  ] not a todo item with 1 non-breaking space and 1 space 13
+- [  ] not a todo item with 1 space and 1 non-breaking space 14
+- [ x] not a todo item with non-breaking space 15
+- [x ] not a todo item with non-breaking space 16
+- [ x ] not a todo item with 2 non-breaking spaces 17
+- [ x ] not a todo item with 1 non-breaking space and 1 space 18
+- [ x ] not a todo item with 1 space and 1 non-breaking space 19
+-   [x] todo item with non-breaking space 20
+- [ X] not a todo item with non-breaking space 21
+- [X ] not a todo item with non-breaking space 22
+- [ X ] not a todo item with 2 non-breaking spaces 23
+- [ X ] not a todo item with 1 space and 1 non-breaking space 24
+- [ X ] not a todo item with 1 non-breaking space and 1 space 25
+-   [X] todo item with non-breaking space 26

--- a/test/fixtures/ordered.md
+++ b/test/fixtures/ordered.md
@@ -1,4 +1,8 @@
 1. [x] checked ordered 1
 2. [ ] unchecked ordered 2
-3. [x] checked ordered 3
+3. [X] checked ordered 3
 4. [ ] unchecked ordered 4
+5. [x] checked ordered non-breaking-space 5
+6. [ ] unchecked ordered non-breaking-space 6
+7. [X] checked ordered non-breaking-space 7
+8. [ ] unchecked ordered non-breaking-space 8

--- a/test/index.js
+++ b/test/index.js
@@ -37,7 +37,7 @@ describe('markdown-it-task-lists', function() {
     });
 
     it('renders items marked up as [ ] as unchecked', function () {
-        var shouldBeUnchecked = (fixtures.ordered.match(/[\.\*\+-]\s+\[ \]/g) || []).length;
+        var shouldBeUnchecked = (fixtures.ordered.match(/[\.\*\+-]\s+\[[ \u00A0]\]/g) || []).length;
         assert.equal($.ordered('input[type=checkbox]:not(:checked)').length, shouldBeUnchecked);
     });
 
@@ -69,6 +69,15 @@ describe('markdown-it-task-lists', function() {
         assert(~html.indexOf('<li>[x ]'));
         assert(~html.indexOf('<li>[ x]'));
         assert(~html.indexOf('<li>[ x ]'));
+        assert(~html.indexOf('<li>[&#xA0; ]'));
+        assert(~html.indexOf('<li>[ &#xA0;]'));
+        assert(~html.indexOf('<li>[&#xA0;&#xA0;]'));
+        assert(~html.indexOf('<li>[&#xA0;]</li>'));
+        assert(~html.indexOf('<li>[x&#xA0;]'));
+        assert(~html.indexOf('<li>[&#xA0;x]'));
+        assert(~html.indexOf('<li>[&#xA0;x ]'));
+        assert(~html.indexOf('<li>[&#xA0;x&#xA0;]'));
+        assert(~html.indexOf('<li>[ x&#xA0;]'));
     });
 
     it('adds class .task-list-item to parent <li>', function () {


### PR DESCRIPTION
Note that since it is markdown-it itself that controls (trims) the whitespace BEFORE [ ], I did not see how to make a fix where it would recognize those checkboxes.